### PR TITLE
Fix requestInit creation due to naming convention change in BuckleScript

### DIFF
--- a/examples/examples.ml
+++ b/examples/examples.ml
@@ -32,9 +32,9 @@ let _ =
     fetch "/api/fruit"
     (* assume server returns `["apple", "banana", "pear", ...]` *)
     |> andThen Response.json
-    |> then_ Js.Json.arrayOfJSON
+    |> then_ Js.Json.decodeArray
     |> then_ Option.unwrapUnsafely
     |> then_ (Js.Array.map
         (fun item ->
-          item |> Js.Json.stringOfJSON |> Option.unwrapUnsafely))
+          item |> Js.Json.decodeString |> Option.unwrapUnsafely))
   )

--- a/src/bs_fetch.ml
+++ b/src/bs_fetch.ml
@@ -273,7 +273,7 @@ module RequestInit = struct
   | None  -> None
 
   external make :
-    ?method_:string ->
+    ?_method:string ->
     ?headers:headersInit ->
     ?body:bodyInit ->
     ?referrer:string ->
@@ -298,7 +298,7 @@ module RequestInit = struct
     ?integrity:(integrity: string = "") 
     ?keepalive:(keepalive: bool option)
     = make
-        ?method_: (map encodeRequestMethod method_)
+        ?_method: (map encodeRequestMethod method_)
         ?headers
         ?body
         ?referrer


### PR DESCRIPTION
I also fix the example to use the latest names.