### PR TITLE
Feature/bind form data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib/*
 .merlin
 .bsb.lock
 node_modules/
+yarn-error.log

--- a/examples/ocaml_examples.ml
+++ b/examples/ocaml_examples.ml
@@ -27,19 +27,22 @@ let _ =
     |> then_ (fun opt -> Option.unwrapUnsafely opt |> resolve)
     |> then_ (fun items ->
         items |> Js.Array.map (fun item ->
-                    item |> Js.Json.decodeString
-                         |> Option.unwrapUnsafely)
-              |> resolve)
+            item |> Js.Json.decodeString
+            |> Option.unwrapUnsafely)
+        |> resolve)
   )
 
 let _ =
+  let headers = [%bs.raw {|
+    {"Content-type": "application/json"}
+  |}] in
   let payload = Js.Dict.empty () in
   Js.Dict.set payload "hello" (Js.Json.string "world");
   let open Js.Promise in
-    (Fetch.fetchWithInit "/api/hello"
-       (Fetch.RequestInit.make ~method_:Post
-          ~body:(Fetch.BodyInit.make
-                   (Js.Json.stringify (Js.Json.object_ payload)))
-          ~headers:(Fetch.HeadersInit.make
-                      ([%bs.obj { contentType = "application/json" }])) ()))
-      |> (then_ Fetch.Response.json)
+  (Fetch.fetchWithInit "/api/hello"
+     (Fetch.RequestInit.make ~method_:Post
+        ~body:(Fetch.BodyInit.make
+                 (Js.Json.stringify (Js.Json.object_ payload)))
+        ~headers:(Fetch.HeadersInit.make
+                    (headers)) ()))
+  |> (then_ Fetch.Response.json)

--- a/examples/ocaml_examples.ml
+++ b/examples/ocaml_examples.ml
@@ -41,5 +41,5 @@ let _ =
           ~body:(Fetch.BodyInit.make
                    (Js.Json.stringify (Js.Json.object_ payload)))
           ~headers:(Fetch.HeadersInit.make
-                      ([%bs.obj { Content-Type = "application/json" }])) ()))
+                      ([%bs.obj { contentType = "application/json" }])) ()))
       |> (then_ Fetch.Response.json)

--- a/examples/reason_examples.re
+++ b/examples/reason_examples.re
@@ -56,7 +56,7 @@ let _ = {
 let _ = {
   let formData = Fetch.FormData.make();
 
-  formData |> Fetch.FormData.mutableAppendObject("image0", {"type": "image/jpg", "uri": "path/to/it", "name": "image0.jpg"});
+  formData |> Fetch.FormData.appendObject("image0", {"type": "image/jpg", "uri": "path/to/it", "name": "image0.jpg"});
 
   Js.Promise.(
     Fetch.fetchWithInit(

--- a/examples/reason_examples.re
+++ b/examples/reason_examples.re
@@ -56,7 +56,7 @@ let _ = {
 let _ = {
   let formData = Fetch.FormData.make();
 
-  formData |> Fetch.FormData.appendObject("image0", {"type": "image/jpg", "uri": "path/to/it", "name": "image0.jpg"});
+  formData |> Fetch.FormData.mutableAppendObject("image0", {"type": "image/jpg", "uri": "path/to/it", "name": "image0.jpg"});
 
   Js.Promise.(
     Fetch.fetchWithInit(

--- a/examples/reason_examples.re
+++ b/examples/reason_examples.re
@@ -52,3 +52,23 @@ let _ = {
     |> then_(Fetch.Response.json)
   );
 };
+
+let _ = {
+  let formData = Fetch.FormData.make();
+
+  formData |> Fetch.FormData.appendObject("image0", {"type": "image/jpg", "uri": "path/to/it", "name": "image0.jpg"});
+
+  Js.Promise.(
+    Fetch.fetchWithInit(
+      "/api/upload",
+      Fetch.RequestInit.make(
+        ~method_=Post,
+        ~body=Fetch.BodyInit.makeWithFormData(formData),
+        ~headers=Fetch.HeadersInit.make({"Accept": "*"}),
+        ()
+      )
+    )
+
+    |> then_(Fetch.Response.json)
+  )
+};

--- a/lib/js/examples/ocaml_examples.js
+++ b/lib/js/examples/ocaml_examples.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var Fetch                   = require("../src/Fetch.js");
-var Js_json                 = require("bs-platform/lib/js/js_json.js");
+var Fetch = require("../src/Fetch.js");
+var Js_json = require("bs-platform/lib/js/js_json.js");
 var Caml_builtin_exceptions = require("bs-platform/lib/js/caml_builtin_exceptions.js");
 
 function unwrapUnsafely(param) {
@@ -39,6 +39,16 @@ fetch("/api/fruit").then((function (prim) {
         return Promise.resolve(items.map((function (item) {
                           return unwrapUnsafely(Js_json.decodeString(item));
                         })));
+      }));
+
+var payload = { };
+
+payload["hello"] = "world";
+
+fetch("/api/hello", Fetch.RequestInit[/* make */0](/* Some */[/* Post */2], /* Some */[{
+                contentType: "application/json"
+              }], /* Some */[JSON.stringify(payload)], /* None */0, /* None */0, /* None */0, /* None */0, /* None */0, /* None */0, /* None */0, /* None */0)(/* () */0)).then((function (prim) {
+        return prim.json();
       }));
 
 exports.Option = Option;

--- a/lib/js/examples/reason_examples.js
+++ b/lib/js/examples/reason_examples.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var Fetch                   = require("../src/Fetch.js");
-var Js_json                 = require("bs-platform/lib/js/js_json.js");
+var Fetch = require("../src/Fetch.js");
+var Js_json = require("bs-platform/lib/js/js_json.js");
 var Caml_builtin_exceptions = require("bs-platform/lib/js/caml_builtin_exceptions.js");
 
 function unwrapUnsafely(data) {
@@ -39,6 +39,30 @@ fetch("/api/fruit").then((function (prim) {
         return Promise.resolve(items.map((function (item) {
                           return unwrapUnsafely(Js_json.decodeString(item));
                         })));
+      }));
+
+var payload = { };
+
+payload["hello"] = "world";
+
+fetch("/api/hello", Fetch.RequestInit[/* make */0](/* Some */[/* Post */2], /* Some */[{
+                "Content-Type": "application/json"
+              }], /* Some */[JSON.stringify(payload)], /* None */0, /* None */0, /* None */0, /* None */0, /* None */0, /* None */0, /* None */0, /* None */0)(/* () */0)).then((function (prim) {
+        return prim.json();
+      }));
+
+var formData = new FormData();
+
+formData.append("image0", {
+      type: "image/jpg",
+      uri: "path/to/it",
+      name: "image0.jpg"
+    });
+
+fetch("/api/upload", Fetch.RequestInit[/* make */0](/* Some */[/* Post */2], /* Some */[{
+                Accept: "*"
+              }], /* Some */[formData], /* None */0, /* None */0, /* None */0, /* None */0, /* None */0, /* None */0, /* None */0, /* None */0)(/* () */0)).then((function (prim) {
+        return prim.json();
       }));
 
 exports.Option = Option;

--- a/lib/js/src/Fetch.js
+++ b/lib/js/src/Fetch.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var Curry                   = require("bs-platform/lib/js/curry.js");
-var Js_boolean              = require("bs-platform/lib/js/js_boolean.js");
+var Curry = require("bs-platform/lib/js/curry.js");
+var Js_boolean = require("bs-platform/lib/js/js_boolean.js");
 var Caml_builtin_exceptions = require("bs-platform/lib/js/caml_builtin_exceptions.js");
 
 function encodeRequestMethod(param) {
@@ -388,15 +388,18 @@ var Request = /* module */[
 
 var Response = /* module */[];
 
+var FormData = /* module */[];
+
 var Body = [];
 
 var RequestInit = [make];
 
 exports.HeadersInit = HeadersInit;
-exports.Headers     = Headers;
-exports.BodyInit    = BodyInit;
-exports.Body        = Body;
+exports.Headers = Headers;
+exports.BodyInit = BodyInit;
+exports.Body = Body;
 exports.RequestInit = RequestInit;
-exports.Request     = Request;
-exports.Response    = Response;
+exports.Request = Request;
+exports.Response = Response;
+exports.FormData = FormData;
 /* No side effect */

--- a/lib/js/src/Fetch.js
+++ b/lib/js/src/Fetch.js
@@ -388,6 +388,8 @@ var Request = /* module */[
 
 var Response = /* module */[];
 
+var Blob = /* module */[];
+
 var FormData = /* module */[];
 
 var Body = [];
@@ -401,5 +403,6 @@ exports.Body = Body;
 exports.RequestInit = RequestInit;
 exports.Request = Request;
 exports.Response = Response;
+exports.Blob = Blob;
 exports.FormData = FormData;
 /* No side effect */

--- a/lib/js/src/bs_fetch.js
+++ b/lib/js/src/bs_fetch.js
@@ -16,11 +16,14 @@ var Request = Fetch.Request;
 
 var Response = Fetch.Response;
 
+var FormData = Fetch.FormData;
+
 exports.HeadersInit = HeadersInit;
-exports.Headers     = Headers;
-exports.BodyInit    = BodyInit;
-exports.Body        = Body;
+exports.Headers = Headers;
+exports.BodyInit = BodyInit;
+exports.Body = Body;
 exports.RequestInit = RequestInit;
-exports.Request     = Request;
-exports.Response    = Response;
+exports.Request = Request;
+exports.Response = Response;
+exports.FormData = FormData;
 /* No side effect */

--- a/lib/js/src/bs_fetch.js
+++ b/lib/js/src/bs_fetch.js
@@ -16,6 +16,8 @@ var Request = Fetch.Request;
 
 var Response = Fetch.Response;
 
+var Blob = Fetch.Blob;
+
 var FormData = Fetch.FormData;
 
 exports.HeadersInit = HeadersInit;
@@ -25,5 +27,6 @@ exports.Body = Body;
 exports.RequestInit = RequestInit;
 exports.Request = Request;
 exports.Response = Response;
+exports.Blob = Blob;
 exports.FormData = FormData;
 /* No side effect */

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "homepage": "https://github.com/reasonml-community/bs-fetch#readme",
   "devDependencies": {
-    "bs-platform": "^2.0.0"
+    "bs-platform": "^2.2.3"
   }
 }

--- a/src/Fetch.ml
+++ b/src/Fetch.ml
@@ -368,11 +368,12 @@ module FormData = struct
 
   external make : unit -> t = "FormData" [@@bs.new]
 
-  external appendObject : string -> < .. > Js.t -> unit = "append" [@@bs.send.pipe : t]
-  external appendString : string -> string -> unit = "append" [@@bs.send.pipe : t]
-  external delete : string -> unit = "delete" [@@bs.send.pipe : t]
-  external setObject : string -> < .. > Js.t -> unit = "set" [@@bs.send.pipe : t]
-  external setString : string -> string -> unit = "set" [@@bs.send.pipe : t]
+  external mutableAppendObject : string -> < .. > Js.t -> unit = "append" [@@bs.send.pipe : t]
+
+  external mutableAppendString : string -> string -> unit = "append" [@@bs.send.pipe : t]
+  external mutableDelete : string -> unit = "delete" [@@bs.send.pipe : t]
+  external mutableSetObject : string -> < .. > Js.t -> unit = "set" [@@bs.send.pipe : t]
+  external mutableSetString : string -> string -> unit = "set" [@@bs.send.pipe : t]
 end
 
 

--- a/src/Fetch.ml
+++ b/src/Fetch.ml
@@ -363,17 +363,27 @@ module Response = struct
   external clone : t = "" [@@bs.send.pipe: t]
 end
 
+(* This belongs to XHR spec and will probably be moved to another repo in the future *)
+
+module Blob = struct
+  type t
+end
+
 module FormData = struct 
   type t = formData
 
   external make : unit -> t = "FormData" [@@bs.new]
 
-  external mutableAppendObject : string -> < .. > Js.t -> unit = "append" [@@bs.send.pipe : t]
+  (* Added for React Native polyfill compatibility *)
+  external appendObject : string -> < .. > Js.t -> unit = "append" [@@bs.send.pipe : t]
+  external appendBlob : string -> Blob.t -> unit = "append" [@@bs.send.pipe : t]
+  external appendString : string -> string -> unit = "append" [@@bs.send.pipe : t]
 
-  external mutableAppendString : string -> string -> unit = "append" [@@bs.send.pipe : t]
-  external mutableDelete : string -> unit = "delete" [@@bs.send.pipe : t]
-  external mutableSetObject : string -> < .. > Js.t -> unit = "set" [@@bs.send.pipe : t]
-  external mutableSetString : string -> string -> unit = "set" [@@bs.send.pipe : t]
+  external delete : string -> unit = "delete" [@@bs.send.pipe : t]
+
+  external setObject : string -> < .. > Js.t -> unit = "set" [@@bs.send.pipe : t]
+  external setBlob : string -> Blob.t -> unit = "set" [@@bs.send.pipe : t]
+  external setString : string -> string -> unit = "set" [@@bs.send.pipe : t]
 end
 
 

--- a/src/Fetch.ml
+++ b/src/Fetch.ml
@@ -363,6 +363,18 @@ module Response = struct
   external clone : t = "" [@@bs.send.pipe: t]
 end
 
+module FormData = struct 
+  type t = formData
+
+  external make : unit -> t = "FormData" [@@bs.new]
+
+  external appendObject : string -> < .. > Js.t -> unit = "append" [@@bs.send.pipe : t]
+  external appendString : string -> string -> unit = "append" [@@bs.send.pipe : t]
+  external delete : string -> unit = "delete" [@@bs.send.pipe : t]
+  external setObject : string -> < .. > Js.t -> unit = "set" [@@bs.send.pipe : t]
+  external setString : string -> string -> unit = "set" [@@bs.send.pipe : t]
+end
+
 
 external fetch : string -> response Js.Promise.t = "" [@@bs.val]
 external fetchWithInit : string -> requestInit -> response Js.Promise.t = "fetch" [@@bs.val]

--- a/src/Fetch.mli
+++ b/src/Fetch.mli
@@ -217,11 +217,12 @@ module FormData : sig
 
   external make : unit -> t = "FormData" [@@bs.new]
 
-  external appendObject : string -> < .. > Js.t -> unit = "append" [@@bs.send.pipe : t]
-  external appendString : string -> string -> unit = "append" [@@bs.send.pipe : t]
-  external delete : string -> unit = "delete" [@@bs.send.pipe : t]
-  external setObject : string -> < .. > Js.t -> unit = "set" [@@bs.send.pipe : t]
-  external setString : string -> string -> unit = "set" [@@bs.send.pipe : t]
+  external mutableAppendObject : string -> < .. > Js.t -> unit = "append" [@@bs.send.pipe : t]
+
+  external mutableAppendString : string -> string -> unit = "append" [@@bs.send.pipe : t]
+  external mutableDelete : string -> unit = "delete" [@@bs.send.pipe : t]
+  external mutableSetObject : string -> < .. > Js.t -> unit = "set" [@@bs.send.pipe : t]
+  external mutableSetString : string -> string -> unit = "set" [@@bs.send.pipe : t]
 end
 
 external fetch : string -> response Js.Promise.t = "" [@@bs.val]

--- a/src/Fetch.mli
+++ b/src/Fetch.mli
@@ -212,6 +212,18 @@ module Response : sig
   external text : string Js.Promise.t = "" [@@bs.send.pipe: t]
 end
 
+module FormData : sig 
+  type t = formData
+
+  external make : unit -> t = "FormData" [@@bs.new]
+
+  external appendObject : string -> < .. > Js.t -> unit = "append" [@@bs.send.pipe : t]
+  external appendString : string -> string -> unit = "append" [@@bs.send.pipe : t]
+  external delete : string -> unit = "delete" [@@bs.send.pipe : t]
+  external setObject : string -> < .. > Js.t -> unit = "set" [@@bs.send.pipe : t]
+  external setString : string -> string -> unit = "set" [@@bs.send.pipe : t]
+end
+
 external fetch : string -> response Js.Promise.t = "" [@@bs.val]
 external fetchWithInit : string -> requestInit -> response Js.Promise.t = "fetch" [@@bs.val]
 external fetchWithRequest : request -> response Js.Promise.t = "fetch" [@@bs.val]

--- a/src/Fetch.mli
+++ b/src/Fetch.mli
@@ -212,17 +212,22 @@ module Response : sig
   external text : string Js.Promise.t = "" [@@bs.send.pipe: t]
 end
 
+module Blob : sig
+  type t
+end
+
 module FormData : sig 
   type t = formData
 
   external make : unit -> t = "FormData" [@@bs.new]
 
-  external mutableAppendObject : string -> < .. > Js.t -> unit = "append" [@@bs.send.pipe : t]
+  external appendObject : string -> < .. > Js.t -> unit = "append" [@@bs.send.pipe : t]
 
-  external mutableAppendString : string -> string -> unit = "append" [@@bs.send.pipe : t]
-  external mutableDelete : string -> unit = "delete" [@@bs.send.pipe : t]
-  external mutableSetObject : string -> < .. > Js.t -> unit = "set" [@@bs.send.pipe : t]
-  external mutableSetString : string -> string -> unit = "set" [@@bs.send.pipe : t]
+  external appendString : string -> string -> unit = "append" [@@bs.send.pipe : t]
+  external delete : string -> unit = "delete" [@@bs.send.pipe : t]
+  external setObject : string -> < .. > Js.t -> unit = "set" [@@bs.send.pipe : t]
+  external setString : string -> string -> unit = "set" [@@bs.send.pipe : t]
+  external setBlob : string -> Blob.t -> unit = "set" [@@bs.send.pipe : t]
 end
 
 external fetch : string -> response Js.Promise.t = "" [@@bs.val]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,6 @@
 # yarn lockfile v1
 
 
-bs-platform@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.0.0.tgz#17ee607fa829f67b8b920438ebca5ec1deab3276"
+bs-platform@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.2.3.tgz#d905ae10a5f3621e6a739041dfa0b58483a2174f"


### PR DESCRIPTION
Add bindings to FormData.
Also I could not get this code compiled:

```ml
let _ =
  let payload = Js.Dict.empty () in
  Js.Dict.set payload "hello" (Js.Json.string "world");
  let open Js.Promise in
    (Fetch.fetchWithInit "/api/hello"
       (Fetch.RequestInit.make ~method_:Post
          ~body:(Fetch.BodyInit.make
                   (Js.Json.stringify (Js.Json.object_ payload)))
          ~headers:(Fetch.HeadersInit.make
                      ([%bs.obj { Content-type = "application/json" }])) ()))
      |> (then_ Fetch.Response.json)
```

exactly because of "Content-type", I had to change to "contentType" to get it accepted. Maybe is something in my env? Was it working for you guys before? Let me know how I can fix this