### PR TITLE
Fix signature for Headers append and delete

### DIFF
--- a/src/Fetch.ml
+++ b/src/Fetch.ml
@@ -230,8 +230,8 @@ module Headers = struct
   external make : t = "Headers" [@@bs.new]
   external makeWithInit : headersInit -> t = "Headers" [@@bs.new]
 
-  external append : string -> string = "" [@@bs.send.pipe: t]
-  external delete : string = "" [@@bs.send.pipe: t]
+  external append : string -> string -> unit = "" [@@bs.send.pipe: t]
+  external delete : string -> unit = "" [@@bs.send.pipe: t]
   (* entries *) (* very experimental *)
   external get : string -> string option = "" [@@bs.send.pipe: t] [@@bs.return {null_to_opt}]
   external has : string -> bool = "" [@@bs.send.pipe: t]

--- a/src/Fetch.mli
+++ b/src/Fetch.mli
@@ -102,8 +102,8 @@ module Headers : sig
   external make : t = "Headers" [@@bs.new]
   external makeWithInit : headersInit -> t = "Headers" [@@bs.new]
 
-  external append : string -> string = "" [@@bs.send.pipe: t]
-  external delete : string = "" [@@bs.send.pipe: t]
+  external append : string -> string -> unit = "" [@@bs.send.pipe: t]
+  external delete : string -> unit = "" [@@bs.send.pipe: t]
   (* entries *) (* very experimental *)
   external get : string -> string option = "" [@@bs.send.pipe: t] [@@bs.return {null_to_opt}]
   external has : string -> bool = "" [@@bs.send.pipe: t]


### PR DESCRIPTION
It seems that the signatures for Headers.append & .delete are wrong. Previously, there were:

```ml
external append : string -> string = "" [@@bs.send.pipe: t]
external delete : string = "" [@@bs.send.pipe: t]
```

However, their usage (in JS) should be

```javascript
headers.append("Content-Type", "application/json");
headers.delete("Content-Type");
```

So I think there should be an extra `-> unit` for both of them.

I've tested my fix with the following (in Reason):

```reason
let headers = Fetch.Headers.make;
Fetch.Headers.append("X-My-Header", "value", headers);
Fetch.Headers.delete("X-My-Header", headers);
```

and the corresponding generated JS (sans extra spacing for readability):

```javascript
'use strict';
var headers = new Headers();
headers.append("X-My-Header", "value");
headers.delete("X-My-Header");
```