### PR TITLE
`Fetch.Response._type` should access the `type` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ See usage examples in [`ocaml_examples.ml`](https://github.com/reasonml-communit
 
 ## Changes
 
+### 0.6.0
+* Bugfix: `Response._type` was generating `_type` instead of `type`
+* Breaking: Rename `Response._type` to `Response.type_` to follow the name mangling convention trends
+
 ### 0.5.2
 * Added `AbortController`
 

--- a/src/Fetch.ml
+++ b/src/Fetch.ml
@@ -373,7 +373,7 @@ module Response = struct
   external redirected : t -> bool = "redirected" [@@bs.get]
   external status : t -> int = "status" [@@bs.get]
   external statusText : t -> string = "statusText" [@@bs.get]
-  external _type : t -> string = "type" [@@bs.get]
+  external type_ : t -> string = "type" [@@bs.get]
   external url : t -> string = "url" [@@bs.get]
 
   external clone : t = "clone" [@@bs.send.pipe: t]

--- a/src/Fetch.ml
+++ b/src/Fetch.ml
@@ -373,7 +373,7 @@ module Response = struct
   external redirected : t -> bool = "redirected" [@@bs.get]
   external status : t -> int = "status" [@@bs.get]
   external statusText : t -> string = "statusText" [@@bs.get]
-  external _type : t -> string = "_type" [@@bs.get]
+  external _type : t -> string = "type" [@@bs.get]
   external url : t -> string = "url" [@@bs.get]
 
   external clone : t = "clone" [@@bs.send.pipe: t]


### PR DESCRIPTION
as per https://developer.mozilla.org/en-US/docs/Web/API/Response/type