### PR TITLE
Add melange to the library dependencies to fix compilation on melange 2.2.0

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,7 @@
 (library
  (name fetch)
  (public_name melange-fetch)
+ (libraries melange)
  (preprocess
   (pps melange.ppx))
  (modes melange))


### PR DESCRIPTION
I tried to add `melange-webapi` to a new Melange 2.2.0 project, but it failed to compile because it looks like Stdlib is only exposed from the `melange` package in 2.2.0. Adding `melange` to the dependencies fixes this issue. I haven't tried `melange-webapi` but I think this change might have to be made in that package as well.