### PR TITLE
remove ocaml constraint

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -23,7 +23,6 @@
  (name melange-fetch)
  (synopsis "Fetch API support for Melange")
  (depends
-  (ocaml
-   (>= "5.1"))
+  ocaml
   (melange
    (>= "2.0.0"))))

--- a/melange-fetch.opam
+++ b/melange-fetch.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/melange-community/melange-fetch"
 bug-reports: "https://github.com/melange-community/melange-fetch"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "5.1"}
+  "ocaml"
   "melange" {>= "2.0.0"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Similar to https://github.com/melange-community/melange-json/pull/8/, removes the constraint on `ocaml` so that it can be installed with melange 3 in ocaml 4.14.