### PR TITLE
Add AbortSignal and aborted binding

### DIFF
--- a/src/Fetch.ml
+++ b/src/Fetch.ml
@@ -21,6 +21,8 @@ module AbortSignal = struct
   type t = signal
 
   external aborted : t -> bool = "aborted" [@@mel.get]
+  
+  external reason : t -> string Js.Nullable.t = "reason" [@@mel.get]
 end
 
 module AbortController = struct

--- a/src/Fetch.ml
+++ b/src/Fetch.ml
@@ -17,6 +17,12 @@ type urlSearchParams (* URL *)
 type blob
 type file
 
+module AbortSignal = struct
+  type t = signal
+
+  external aborted : t -> bool = "aborted" [@@mel.get]
+end
+
 module AbortController = struct
   type t = abortController
 

--- a/src/Fetch.mli
+++ b/src/Fetch.mli
@@ -32,6 +32,12 @@ type requestMethod =
   | Patch
   | Other of string
 
+module AbortSignal : sig
+  type t = signal
+
+  external aborted : t -> bool = "aborted" [@@mel.get]
+end
+
 module AbortController : sig
   (* Experimental API *)
   type t = abortController

--- a/src/Fetch.mli
+++ b/src/Fetch.mli
@@ -36,6 +36,11 @@ module AbortSignal : sig
   type t = signal
 
   external aborted : t -> bool = "aborted" [@@mel.get]
+  
+  
+  external reason : t -> string Js.Nullable.t = "reason" [@@mel.get]
+  (** A JavaScript value that indicates the abort reason, or undefined,
+      if not aborted. *)
 end
 
 module AbortController : sig


### PR DESCRIPTION
This PR adds the `aborted` binding under a new `AbortSignal` module.
[API reference](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/aborted) for `AbortSignal.aborted`